### PR TITLE
Reduce client assertion lifetime

### DIFF
--- a/src/main/kotlin/no/ks/fiks/helseid/HelseIdClient.kt
+++ b/src/main/kotlin/no/ks/fiks/helseid/HelseIdClient.kt
@@ -46,7 +46,7 @@ private object FormFields {
     const val GRANT_TYPE = "grant_type"
 }
 
-private val jwtRequestLifetime = Duration.ofSeconds(60)
+private val jwtRequestLifetime = Duration.ofSeconds(5)
 
 private val log = KotlinLogging.logger { }
 

--- a/src/test/kotlin/no/ks/fiks/helseid/HelseIdClientTest.kt
+++ b/src/test/kotlin/no/ks/fiks/helseid/HelseIdClientTest.kt
@@ -68,7 +68,7 @@ class HelseIdClientTest : FreeSpec({
                     issueTime.toInstant() shouldBeBefore Instant.now()
                     jwtid shouldNot beNull()
                     notBeforeTime.toInstant() shouldBeBefore Instant.now()
-                    expirationTime.toInstant().shouldBeBetween(Instant.now().plusSeconds(55), Instant.now().plusSeconds(65))
+                    expirationTime.toInstant().shouldBeBetween(Instant.now().plusSeconds(3), Instant.now().plusSeconds(7))
                 }
             }
         }
@@ -224,7 +224,7 @@ class HelseIdClientTest : FreeSpec({
                     issueTime.toInstant() shouldBeBefore Instant.now()
                     jwtid shouldNot beNull()
                     notBeforeTime.toInstant() shouldBeBefore Instant.now()
-                    expirationTime.toInstant().shouldBeBetween(Instant.now().plusSeconds(55), Instant.now().plusSeconds(65))
+                    expirationTime.toInstant().shouldBeBetween(Instant.now().plusSeconds(3), Instant.now().plusSeconds(7))
                     getJSONObjectClaim("assertion_details")["practitioner_role"]
                         .let { it as Map<*, *> }["organization"]
                         .let { it as Map<*, *> }["identifier"]
@@ -278,7 +278,7 @@ class HelseIdClientTest : FreeSpec({
                     issueTime.toInstant() shouldBeBefore Instant.now()
                     jwtid shouldNot beNull()
                     notBeforeTime.toInstant() shouldBeBefore Instant.now()
-                    expirationTime.toInstant().shouldBeBetween(Instant.now().plusSeconds(55), Instant.now().plusSeconds(65))
+                    expirationTime.toInstant().shouldBeBetween(Instant.now().plusSeconds(3), Instant.now().plusSeconds(7))
                     getJSONObjectClaim("assertion_details")["practitioner_role"]
                         .let { it as Map<*, *> }["organization"]
                         .let { it as Map<*, *> }["identifier"]
@@ -370,7 +370,7 @@ class HelseIdClientTest : FreeSpec({
                         issueTime.toInstant() shouldBeBefore Instant.now()
                         jwtid shouldNot beNull()
                         notBeforeTime.toInstant() shouldBeBefore Instant.now()
-                        expirationTime.toInstant().shouldBeBetween(Instant.now().plusSeconds(55), Instant.now().plusSeconds(65))
+                        expirationTime.toInstant().shouldBeBetween(Instant.now().plusSeconds(3), Instant.now().plusSeconds(7))
                     }
                 }
             }
@@ -424,7 +424,7 @@ class HelseIdClientTest : FreeSpec({
                         issueTime.toInstant() shouldBeBefore Instant.now()
                         jwtid shouldNot beNull()
                         notBeforeTime.toInstant() shouldBeBefore Instant.now()
-                        expirationTime.toInstant().shouldBeBetween(Instant.now().plusSeconds(55), Instant.now().plusSeconds(65))
+                        expirationTime.toInstant().shouldBeBetween(Instant.now().plusSeconds(3), Instant.now().plusSeconds(7))
                     }
                 }
             }


### PR DESCRIPTION
Change the client assertion lifetime to be in line with the API requirements specified at https://utviklerportal.nhn.no/informasjonstjenester/helseid/bruksmoenstre-og-eksempelkode/bruk-av-helseid/docs/tekniske-mekanismer/bruk_av_client_assertion_enmd, specifically: 
> `exp - The last time the JWT can be used. Expressed in seconds as "epoch time". This value shall not be set to more than 10 seconds in the future.`

10 seconds is just the maximum allowed lifetime, and it should optimally be even lower, which is why we now set the assertion expiry only 5 seconds in the future.